### PR TITLE
change default value of tr_iso to true

### DIFF
--- a/bld/namelist_files/namelist_defaults_cice.xml
+++ b/bld/namelist_files/namelist_defaults_cice.xml
@@ -169,7 +169,7 @@
 <tr_pond> .true. </tr_pond>
 
 <tr_aero> .true. </tr_aero>
-<tr_iso> .false. </tr_iso>
+<tr_iso> .true. </tr_iso>
 
 <!--------------------------->
 <!-- Domain namelist- --->


### PR DESCRIPTION
change default value of tr_iso to true, so that it is easier to set up isotope runs.